### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/iolave/go-logger/security/code-scanning/1](https://github.com/iolave/go-logger/security/code-scanning/1)

To fix this issue, we should explicitly set the `permissions` key to the least required privilege. In this workflow, all steps only need to check out code and run tests—no writing to pull requests, issues, or publishing content is performed. The minimal permission required is `contents: read`. The `permissions` block can be placed at the workflow root (affecting all jobs), or per job. Since there is just one job, it is simplest and clearest to put it at the root, immediately below the workflow `name`.

**How to fix:**  
- Insert a `permissions` block at the root, just after the workflow `name`.
- Set it to `contents: read`.

**Specifics:**  
- In the `.github/workflows/test.yml` file, add the following lines after `name: Test` and before `on:`.
- This ensures the workflow only grants read access to repository contents for the `GITHUB_TOKEN`, complying with least privilege principles and CodeQL guidance.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
